### PR TITLE
Return the exit status of the child process instead of its pid.

### DIFF
--- a/cninja
+++ b/cninja
@@ -321,7 +321,9 @@ while ( sysread( $pty, $nbuf, 4096 ) || $signaled )
 }
 
 # Get the return code of ninja and exit with that.
-my $ret = waitpid( $pid, 0 );
+waitpid( $pid, 0 );
+my $ret = $?;
+
 close $pty;
 
 exit( $ret >> 8 );


### PR DESCRIPTION
Thank you for putting this together!  It's nice having colored output from ninja.  The only issue I noticed was this.  You were expecting `waitpid()` to return the status, but it doesn't.  `waitpid()` returns the pid of the process, and sets `$?` to the status.  So this fixes that minor mistake.
