### PR TITLE
Look for ninja-build and ninja.

### DIFF
--- a/cninja
+++ b/cninja
@@ -2,11 +2,23 @@
 
 use strict;
 use warnings;
+use File::Which;
 use Getopt::Long;
 use Term::ANSIColor;
 use IO::Pty;
 
-my $ninja = "ninja";
+my $ninja = which "ninja-build";
+if (! defined($ninja))
+{
+    $ninja = which "ninja";
+}
+
+if (! defined($ninja))
+{
+    print "ERROR: No suitable ninja binary found.";
+    exit(1);
+}
+
 my @ninjaArgs = ();
 
 my $reset = color("reset");


### PR DESCRIPTION
Fedora and CentOS have taken to calling the ninja executable
"ninja-build", meaning cninja doesn't work out of the box.  It's easy
enough to create a symlink somewhere to fix the problem, but it seemed
like a better idea to make cninja work out-of-the-box.

This does introduce the use of the File::Which package to help search
the path for the binary, which adds an extra dependency.